### PR TITLE
renamed roles parameter allowed_node_types to allowed_server_roles

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -87,11 +87,11 @@ func TestBackend_RoleCRUD(t *testing.T) {
 	}
 
 	testRoleConfig := roleConfig{
-		Connection:       "testconn",
-		Roles:            []string{"admin"},
-		AllowedNodeTypes: []string{"*"},
-		PasswordSpec:     DefaultPasswordSpec(),
-		UserPrefix:       "my-custom-prefix",
+		Connection:         "testconn",
+		Roles:              []string{"admin"},
+		AllowedServerRoles: []string{"*"},
+		PasswordSpec:       DefaultPasswordSpec(),
+		UserPrefix:         "my-custom-prefix",
 	}
 
 	logicaltest.Test(t, logicaltest.TestCase{

--- a/path_creds_create.go
+++ b/path_creds_create.go
@@ -129,15 +129,15 @@ func findNode(nodeFQDN string, hosts []splunk.ServerInfoEntry, roleConfig *roleC
 		// check if node_fqdn is in either of HostFQDN or Host. User might not always the FQDN on the cli input
 		if host.Content.HostFQDN == nodeFQDN || host.Content.Host == nodeFQDN {
 			// Return true if the requested node type is allowed
-			if strutil.StrListContains(roleConfig.AllowedNodeTypes, "*") {
+			if strutil.StrListContains(roleConfig.AllowedServerRoles, "*") {
 				return true, nil
 			}
 			for _, role := range host.Content.Roles {
-				if strutil.StrListContainsGlob(roleConfig.AllowedNodeTypes, role) {
+				if strutil.StrListContainsGlob(roleConfig.AllowedServerRoles, role) {
 					return true, nil
 				}
 			}
-			return false, fmt.Errorf("host %q does not have an allowed node type", nodeFQDN)
+			return false, fmt.Errorf("host %q does not have any of the allowed server roles: %q", nodeFQDN, roleConfig.AllowedServerRoles)
 		}
 	}
 	return false, fmt.Errorf("host %q not found", nodeFQDN)

--- a/path_roles.go
+++ b/path_roles.go
@@ -35,7 +35,7 @@ func (b *backend) pathRoles() *framework.Path {
 				Type:        framework.TypeCommaStringSlice,
 				Description: "Comma-separated string or list of Splunk roles.",
 			},
-			"allowed_node_types": &framework.FieldSchema{
+			"allowed_server_roles": &framework.FieldSchema{
 				Type: framework.TypeCommaStringSlice,
 				Description: trimIndent(`
 				Comma-separated string or array of node type (glob) patterns that are allowed
@@ -122,8 +122,8 @@ func (b *backend) rolesWriteHandler(ctx context.Context, req *logical.Request, d
 	if maxTTLRaw, ok := getValue(data, req.Operation, "max_ttl"); ok {
 		role.MaxTTL = time.Duration(maxTTLRaw.(int)) * time.Second
 	}
-	if allowed_node_types, ok := getValue(data, req.Operation, "allowed_node_types"); ok {
-		role.AllowedNodeTypes = allowed_node_types.([]string)
+	if allowedServerRoles, ok := getValue(data, req.Operation, "allowed_server_roles"); ok {
+		role.AllowedServerRoles = allowedServerRoles.([]string)
 	}
 	role.PasswordSpec = DefaultPasswordSpec() // XXX make configurable
 

--- a/role.go
+++ b/role.go
@@ -11,11 +11,11 @@ import (
 )
 
 type roleConfig struct {
-	Connection       string        `json:"connection" structs:"connection"`
-	DefaultTTL       time.Duration `json:"default_ttl" structs:"default_ttl"`
-	MaxTTL           time.Duration `json:"max_ttl" structs:"max_ttl"`
-	AllowedNodeTypes []string      `json:"allowed_node_types" structs:"allowed_node_types"`
-	PasswordSpec     *PasswordSpec `json:"password_spec" structs:"password_spec"`
+	Connection         string        `json:"connection" structs:"connection"`
+	DefaultTTL         time.Duration `json:"default_ttl" structs:"default_ttl"`
+	MaxTTL             time.Duration `json:"max_ttl" structs:"max_ttl"`
+	AllowedServerRoles []string      `json:"allowed_server_roles" structs:"allowed_server_roles"`
+	PasswordSpec       *PasswordSpec `json:"password_spec" structs:"password_spec"`
 
 	// Splunk user attributes
 	Roles      []string `json:"roles" structs:"roles"`


### PR DESCRIPTION
To conform with the returned responses from the `search/distributed/peers`.