### PR TITLE
Shorten generated usernames, add option user_id_scheme for roles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
+	github.com/mr-tron/base58 v1.1.3
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/mr-tron/base58 v1.1.3 h1:v+sk57XuaCKGXpWtVBX8YJzO7hMGx4Aajh4TQbdEFdc=
+github.com/mr-tron/base58 v1.1.3/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/path_creds_create.go
+++ b/path_creds_create.go
@@ -252,7 +252,18 @@ func (b *backend) credsReadHandler(ctx context.Context, req *logical.Request, d 
 }
 
 func generateUserID(roleConfig *roleConfig) (string, error) {
-	return uuid.GenerateUUID()
+	switch roleConfig.UserIDScheme {
+	case userIDSchemeUUID4_v0_5_0:
+		fallthrough
+	case userIDSchemeUUID4:
+		return uuid.GenerateUUID()
+	case userIDSchemeBase58_64:
+		return GenerateShortUUID(8)
+	case userIDSchemeBase58_128:
+		return GenerateShortUUID(16)
+	default:
+		return "", fmt.Errorf("invalid user_id_scheme: %q", roleConfig.UserIDScheme)
+	}
 }
 
 func generateUserPassword(roleConfig *roleConfig) (string, error) {

--- a/role.go
+++ b/role.go
@@ -18,11 +18,12 @@ type roleConfig struct {
 	PasswordSpec       *PasswordSpec `json:"password_spec" structs:"password_spec"`
 
 	// Splunk user attributes
-	Roles      []string `json:"roles" structs:"roles"`
-	DefaultApp string   `json:"default_app,omitempty" structs:"default_app"`
-	Email      string   `json:"email,omitempty" structs:"email"`
-	TZ         string   `json:"tz,omitempty" structs:"tz"`
-	UserPrefix string   `json:"user_prefix,omitempty" structs:"user_prefix"`
+	Roles        []string `json:"roles" structs:"roles"`
+	DefaultApp   string   `json:"default_app,omitempty" structs:"default_app"`
+	Email        string   `json:"email,omitempty" structs:"email"`
+	TZ           string   `json:"tz,omitempty" structs:"tz"`
+	UserPrefix   string   `json:"user_prefix,omitempty" structs:"user_prefix"`
+	UserIDScheme string   `json:"user_id_scheme,omitempty" structs:"user_id_scheme"`
 }
 
 // Role returns nil if role named `name` does not exist in `storage`, otherwise

--- a/uuid.go
+++ b/uuid.go
@@ -1,0 +1,18 @@
+package splunk
+
+import (
+	"github.com/hashicorp/go-uuid"
+	"github.com/mr-tron/base58"
+)
+
+func GenerateShortUUID(size int) (string, error) {
+	bytes, err := uuid.GenerateRandomBytes(size)
+	if err != nil {
+		return "", err
+	}
+	return FormatShortUUID(bytes), nil
+}
+
+func FormatShortUUID(bytes []byte) string {
+	return base58.Encode(bytes)
+}

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -1,0 +1,60 @@
+package splunk
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/mr-tron/base58"
+	"gotest.tools/assert"
+)
+
+func TestGenerateShortUUID(t *testing.T) {
+	for _, size := range []int{8, 16} {
+		uuid, err := GenerateShortUUID(size)
+		assert.NilError(t, err)
+		fmt.Println(uuid)
+		bytes, err := base58.Decode(uuid)
+		assert.NilError(t, err)
+		assert.Equal(t, size, len(bytes))
+	}
+}
+
+func TestFormatShortUUID(t *testing.T) {
+	type args struct {
+		bytes []byte
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "0_x_8",
+			args: args{[]byte{0, 0, 0, 0, 0, 0, 0, 0}},
+			want: "11111111",
+		},
+		{
+			name: "1_x_8",
+			args: args{[]byte{0, 0, 0, 0, 0, 0, 0, 1}},
+			want: "11111112",
+		},
+		{
+			name: "255_x_8",
+			args: args{[]byte{255, 255, 255, 255, 255, 255, 255, 255}},
+			want: "jpXCZedGfVQ",
+		},
+		{
+			name: "uuid4",
+			args: args{[]byte{0xb3, 0x3b, 0x6b, 0x76, 0xcb, 0x1f, 0xbe, 0x28, 0xbd, 0x5b, 0x86, 0xca, 0x76, 0x23, 0x72, 0x72}},
+			want: "P8gD5AcMf2n6FkGz9nydEZ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatShortUUID(tt.args.bytes); got != tt.want {
+				t.Errorf("FormatShortUUID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
default: base58-64 (8 chars entropy encoded as base58 string)

For backward compatibility with 0.5.0, unset user_id_scheme is
interpreted as "uuid4".

Fixes #26