### PR TITLE
Use host value from cluster master to connect to

### DIFF
--- a/path_config_connection.go
+++ b/path_config_connection.go
@@ -252,7 +252,7 @@ func (b *backend) connectionWriteHandler(ctx context.Context, req *logical.Reque
 
 func (b *backend) pathConnectionsList() *framework.Path {
 	return &framework.Path{
-		Pattern: fmt.Sprintf("config/?$"),
+		Pattern: "config/?$",
 
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.ListOperation: b.connectionListHandler,

--- a/path_creds_create_test.go
+++ b/path_creds_create_test.go
@@ -136,7 +136,7 @@ func Test_findNode(t *testing.T) {
 				t.Errorf("findNode() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
+			if (got != nil) != tt.want {
 				t.Errorf("findNode() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
This allows using short hostnames when requesting credentials.